### PR TITLE
statsd: make viterbi and reed_solomon errors a statsd gauge

### DIFF
--- a/src/goesrecv/monitor.cc
+++ b/src/goesrecv/monitor.cc
@@ -193,7 +193,7 @@ void Monitor::process(const std::string& json) {
 
     if (key == "viterbi_errors") {
       stats_.viterbiErrors.push_back(value.get<int>());
-      statsd << key << ":" << value.get<int>() << "|h" << std::endl;
+      statsd << key << ":" << value.get<int>() << "|g" << std::endl;
       continue;
     }
 
@@ -201,7 +201,7 @@ void Monitor::process(const std::string& json) {
       const auto& v = value.get<int>();
       if (v >= 0) {
         stats_.reedSolomonErrors.push_back(v);
-        statsd << key << ":" << v << "|h" << std::endl;
+        statsd << key << ":" << v << "|g" << std::endl;
       }
       continue;
     }


### PR DESCRIPTION
I might be incorrect, but I think statsd/graphite/grafana is having a hard time with the `|h` metric type. Making it a gauge makes good graphs:

<img width="743" alt="screen shot 2018-09-09 at 2 12 44 pm" src="https://user-images.githubusercontent.com/1486609/45268986-83f87080-b43a-11e8-8e31-e23c4605141b.png">
