### PR TITLE
Add sample service files to automatically start goesproc/recv

### DIFF
--- a/scripts/services/README.md
+++ b/scripts/services/README.md
@@ -1,0 +1,18 @@
+# Sample services for Raspberry Pi
+
+Those two service files can be installed on a Raspberry Pi and will automatically start/restart both goesrecv and goesproc at boot time.
+
+By default they will use configuration files in /home/pi and save incoming data in /home/pi/incoming, but you can of course adjust those before installing the services.
+
+## How to install
+
+After editing them to adjust paths if necessary, copy both service files to `/etc/systemd/system`. Make sure the configuration files exist, and the `incoming` directory is created at the location referenced in the service description file.
+
+You should then test if the service starts properly by using `sudo systemctl start goesrecv.service`  and `sudo systemctl start goesproc.service`.
+
+If all goes well, then you can simply enable the services so that they run at boot time:
+
+`
+sudo systemctl enable goesrecv.service
+sudo systemctl enable goesproc.service
+`

--- a/scripts/services/goesproc.service
+++ b/scripts/services/goesproc.service
@@ -1,0 +1,19 @@
+# Goesproc service for systemd
+
+[Unit]
+Description=goesproc decoding for the GOES-R satellites
+Documentation=https://pietern.github.io/goestools/
+Wants=network.target
+After=network.target goesrecv.service
+
+[Service]
+WorkingDirectory=/home/pi/incoming
+ExecStart=/usr/local/bin/goesproc -c /home/pi/goesproc-goesr.conf -m packet --subscribe tcp://127.0.0.1:5004
+StandardOutput=null
+Type=simple
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+

--- a/scripts/services/goesrecv.service
+++ b/scripts/services/goesrecv.service
@@ -1,0 +1,20 @@
+# goesrecv service for systemd
+
+[Unit]
+Description=goesrecv reception chain for the GOES-R satellites
+Documentation=https://pietern.github.io/goestools/
+Wants=network.target
+After=network.target
+
+[Service]
+# EnvironmentFile=/etc/default/goestools
+ExecStart=/usr/local/bin/goesrecv -i 10 -c /home/pi/goesrecv.conf 
+StandardOutput=null
+Type=simple
+Restart=on-failure
+RestartSec=30
+Nice=-5
+
+[Install]
+WantedBy=default.target
+


### PR DESCRIPTION
This is a small addition, but I have tested those service files for multiple weeks now, and they work reliably. They do rely on configuration and save location to be in /home/pi by default.