### PR TITLE
Allow compiling against proj 5 too

### DIFF
--- a/src/goesproc/proj.h
+++ b/src/goesproc/proj.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#if PROJ_VERSION_MAJOR != 4
-#error "proj version 4 required"
+#if PROJ_VERSION_MAJOR < 4 || PROJ_VERSION_MAJOR > 5
+#error "proj version 4 or 5 required"
 #endif
 
 #include <map>


### PR DESCRIPTION
Proj 5 (at least proj 5.20 which is installed by Ubuntu 19.04) appears to be backwards compatible with Proj 4 when including `proj_api.h`, so allow the compile to proceed when either of these versions are detected.

Addresses #39.