### PR TITLE
Set default interval value for goesrecv

### DIFF
--- a/src/goesrecv/options.cc
+++ b/src/goesrecv/options.cc
@@ -25,6 +25,9 @@ void usage(int argc, char** argv) {
   exit(0);
 }
 
+Options::Options() : interval(std::chrono::seconds(1)) {
+}
+
 Options parseOptions(int argc, char** argv) {
   Options opts;
 
@@ -96,10 +99,6 @@ Options parseOptions(int argc, char** argv) {
       fprintf(stderr, "Try '%s --help' for more information.\n", argv[0]);
       exit(1);
     }
-  }
-
-  if (opts.verbose && opts.interval.count() == 0) {
-    opts.interval = std::chrono::seconds(1);
   }
 
   return opts;

--- a/src/goesrecv/options.h
+++ b/src/goesrecv/options.h
@@ -4,6 +4,8 @@
 #include <string>
 
 struct Options {
+  Options();
+
   std::string config;
   bool verbose;
   std::chrono::milliseconds interval;


### PR DESCRIPTION
On aarch64, `interval` was initialized to some random value. Specifically initializing it to zero produced the same behavior I observed on x86 machines, where the check for zero would change the value to 1.

If you'd prefer I just initialize it to 1 and drop the later defaulting snippet, just say the word, but I thought this was the best way to preserve existing behavior.

Thanks!