### PR TITLE
Use a different value to detect NEON in compiler

### DIFF
--- a/src/goesrecv/agc.cc
+++ b/src/goesrecv/agc.cc
@@ -2,7 +2,7 @@
 
 #include <cmath>
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
 
@@ -13,7 +13,7 @@ AGC::AGC() {
   gain_ = 1e0f;
 }
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 
 void AGC::work(
     size_t nsamples,

--- a/src/goesrecv/costas.cc
+++ b/src/goesrecv/costas.cc
@@ -4,7 +4,7 @@
 
 #include <util/error.h>
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 #include "./neon/neon_mathfun.h"
 #endif
 
@@ -20,7 +20,7 @@ Costas::Costas() {
   maxDeviation_ = M_2PI;
 }
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 
 void Costas::work(
     size_t nsamples,

--- a/src/goesrecv/rrc.cc
+++ b/src/goesrecv/rrc.cc
@@ -2,7 +2,7 @@
 
 #include <cstring>
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
 
@@ -75,7 +75,7 @@ RRC::RRC(int decimation, int sampleRate, int symbolRate) :
   tmp_.resize(NTAPS);
 }
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 
 void RRC::work(
     size_t nsamples,

--- a/src/goesrecv/rtlsdr_source.cc
+++ b/src/goesrecv/rtlsdr_source.cc
@@ -6,7 +6,7 @@
 #include <cmath>
 #include <iostream>
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 #include <arm_neon.h>
 #endif
 
@@ -153,7 +153,7 @@ void RTLSDR::stop() {
   queue_.reset();
 }
 
-#ifdef __ARM_NEON__
+#ifdef __ARM_NEON
 
 void RTLSDR::process(
     size_t nsamples,


### PR DESCRIPTION
From what I can tell, all aarch64 chips support NEON. With the compilers on my system, `__ARM_NEON__` is not set for aarch64, but `__ARM_NEON` is set for both aarch64 and armv7 with -mfpu=neon.

On armv7hl:
```
$ gcc -mfpu=neon -dM -E - < /dev/null | grep NEON
#define __ARM_NEON_FP 4
#define __ARM_NEON__ 1
#define __ARM_NEON 1
```

On aarch64 (`-mfpu=neon` is not valid because all aarch64 support NEON):
```
$ gcc -dM -E - < /dev/null | grep NEON
#define __ARM_NEON 1
```