### PR TITLE
Airspy: Added options to separately control the gain values

### DIFF
--- a/src/goesrecv/airspy_source.cc
+++ b/src/goesrecv/airspy_source.cc
@@ -73,6 +73,16 @@ void Airspy::setGain(int gain) {
   ASSERT(rv >= 0);
 }
 
+void Airspy::setGainDetailed(int lnaGain, int mixGain, int vgaGain) {
+  ASSERT(dev_ != nullptr);
+  auto rv1 = airspy_set_lna_gain(dev_, lnaGain);
+  ASSERT(rv1 >= 0);
+  auto rv2 = airspy_set_mixer_gain(dev_, mixGain);
+  ASSERT(rv2 >= 0);
+  auto rv3 = airspy_set_vga_gain(dev_, vgaGain);
+  ASSERT(rv3 >= 0);
+}
+
 void Airspy::setBiasTee(bool on) {
   ASSERT(dev_ != nullptr);
   auto rv = airspy_set_rf_bias(dev_, on ? 1 : 0);

--- a/src/goesrecv/airspy_source.h
+++ b/src/goesrecv/airspy_source.h
@@ -29,6 +29,8 @@ public:
 
   void setGain(int gain);
 
+  void setGainDetailed(int lnaGain, int mixGain, int vgaGain);
+
   void setBiasTee(bool on);
 
   void setSamplePublisher(std::unique_ptr<SamplePublisher> samplePublisher) {

--- a/src/goesrecv/config.cc
+++ b/src/goesrecv/config.cc
@@ -144,6 +144,22 @@ void loadAirspySource(Config::Airspy& out, const toml::Value& v) {
       continue;
     }
 
+    if (key == "lna_gain")
+    {
+      out.lna_gain = value.as<int>();
+      continue;
+    }
+    if (key == "vga_gain")
+    {
+      out.vga_gain = value.as<int>();
+      continue;
+    }
+    if (key == "mix_gain")
+    {
+      out.mix_gain = value.as<int>();
+      continue;
+    }
+
     if (key == "sample_publisher") {
       out.samplePublisher = createSamplePublisher(value);
       continue;

--- a/src/goesrecv/config.h
+++ b/src/goesrecv/config.h
@@ -40,6 +40,11 @@ struct Config {
     // Applies to the linearity gain setting
     uint8_t gain = 18;
 
+   // separate gain values for more control - override linearity setting, if any is set > 0
+    uint8_t  lna_gain = 0;
+    uint8_t  vga_gain = 0;
+    uint8_t  mix_gain = 0;
+
     // Enable/disable bias tee
     bool bias_tee = 0;
 

--- a/src/goesrecv/source.cc
+++ b/src/goesrecv/source.cc
@@ -42,7 +42,14 @@ std::unique_ptr<Source> Source::build(
       airspy->setSampleRate(rates[0]);
     }
     airspy->setFrequency(config.airspy.frequency);
-    airspy->setGain(config.airspy.gain);
+    if(config.airspy.lna_gain > 0 || config.airspy.mix_gain > 0 || config.airspy.vga_gain > 0)
+    {
+      airspy->setGainDetailed(config.airspy.lna_gain, config.airspy.mix_gain, config.airspy.vga_gain);
+    }
+    else
+    {
+      airspy->setGain(config.airspy.gain);
+    }
     airspy->setBiasTee(config.airspy.bias_tee);
     airspy->setSamplePublisher(std::move(config.airspy.samplePublisher));
     return std::unique_ptr<Source>(airspy.release());


### PR DESCRIPTION
I thought it may be useful to be able to set LNA gain, mixer gain and vga gain separately, similar to how you can configure the Airspy in SDRSharp, for more control.

If none of these values are configured, the behavior of goesrecv doesn't change.

If any of these is configured > 0, the three values will take effect over the linearity gain setting.
All of the values must then be set in the configuration, because they otherwise default to 0.