### PR TITLE
Issue #55: Initializing tm struct before use with mktime().

### DIFF
--- a/src/util/time.cc
+++ b/src/util/time.cc
@@ -1,7 +1,7 @@
 #include "time.h"
 
 #include <array>
-
+#include <cstring>
 #include <util/error.h>
 
 namespace util {
@@ -22,6 +22,10 @@ std::string stringTime() {
 bool parseTime(const std::string& in, struct timespec* ts) {
   const char* buf = in.c_str();
   struct tm tm;
+
+  //initialize tm struct to 0s before using it, otherwise mktime will behave unpredictably - Kons
+  memset(&tm, 0x0, sizeof(tm));
+
   long int tv_nsec = 0;
 
   // For example: 2017-12-21T17:46:32.2Z
@@ -42,6 +46,10 @@ bool parseTime(const std::string& in, struct timespec* ts) {
   }
 
   auto t = mktime(&tm);
+
+  //the resulting t should always be greater 0, otherwise there was a problem with date conversion
+  ASSERT(t > 0);
+
   ts->tv_sec = t;
   ts->tv_nsec = tv_nsec;
   return true;

--- a/src/util/time.cc
+++ b/src/util/time.cc
@@ -23,7 +23,7 @@ bool parseTime(const std::string& in, struct timespec* ts) {
   const char* buf = in.c_str();
   struct tm tm;
 
-  //initialize tm struct to 0s before using it, otherwise mktime will behave unpredictably - Kons
+  // Initialize tm struct to 0s before using it, otherwise mktime will behave unpredictably - Kons
   memset(&tm, 0x0, sizeof(tm));
 
   long int tv_nsec = 0;
@@ -47,7 +47,7 @@ bool parseTime(const std::string& in, struct timespec* ts) {
 
   auto t = mktime(&tm);
 
-  //the resulting t should always be greater 0, otherwise there was a problem with date conversion
+  // The resulting t should always be greater 0, otherwise there was a problem with date conversion
   ASSERT(t > 0);
 
   ts->tv_sec = t;


### PR DESCRIPTION
Timestamp parsing behavior now consistent. Needs a test on a Raspberry.