### PR TITLE
Added config option for EMWIN handler to disable output of TXT files

### DIFF
--- a/src/goesproc/config.cc
+++ b/src/goesproc/config.cc
@@ -174,6 +174,11 @@ bool loadHandlers(const toml::Value& v, Config& out) {
       h.json = json->as<bool>();
     }
 
+    auto exclude_txt = th->find("exclude_txt");
+    if (exclude_txt) {
+      h.exclude_txt = exclude_txt->as<bool>();
+    }
+
     auto crop = th->find("crop");
     if (crop) {
       auto vs = crop->as<std::vector<int>>();

--- a/src/goesproc/config.h
+++ b/src/goesproc/config.h
@@ -51,6 +51,9 @@ struct Config {
     // Write LRIT header contents as JSON file.
     bool json = false;
 
+    // Exclude TXT files from EMWIN.
+    bool exclude_txt = false;
+
     // Crop (applied before scaling)
     Area crop;
 

--- a/src/goesproc/handler_emwin.cc
+++ b/src/goesproc/handler_emwin.cc
@@ -52,6 +52,13 @@ void EMWINHandler::handle(std::shared_ptr<const lrit::File> f) {
       auto zip = Zip(f->getData());
       fb.filename = zip.fileName();
 
+      // Don't write file if EMWIN TXT is disabled in config
+      if (config_.exclude_txt) {
+        if (fb.filename.substr(fb.filename.length() - 3) == "TXT") {
+          return;
+        }
+      }
+
       // Use filename and extension straight from ZIP file
       const auto path = fb.build("{filename}");
       fileWriter_->write(path, zip.read());
@@ -66,6 +73,12 @@ void EMWINHandler::handle(std::shared_ptr<const lrit::File> f) {
 
   // Write with TXT extension if this is not a compressed file
   if (nlh.noaaSpecificCompression == 0) {
+    
+    // Don't write file if EMWIN TXT is disabled in config
+    if (config_.exclude_txt) {
+      return;
+    }
+
     fb.filename = removeSuffix(text);
 
     // Compressed TXT files also use the uppercase TXT extension


### PR DESCRIPTION
A lot of people seem to want to disable the rather spammy (yet informational) TXT files that come down when EMWIN is disabled, so I added a quick config option to alleviate this, so that only the images people are interested in get downlinked.