### PR TITLE
Include cstdint for uint8_t

### DIFF
--- a/src/lib/packet_reader.h
+++ b/src/lib/packet_reader.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 
 // PacketReader is an abstract base class for things that read packets.
 class PacketReader {

--- a/src/lib/packet_writer.h
+++ b/src/lib/packet_writer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <ctime>
 
 // PacketWriter is an abstract base class for things that write packets.


### PR DESCRIPTION
These headers reference `uint8_t`, so they should include `cstdint`.
Reference: http://www.cplusplus.com/reference/cstdint/

Without this, goestools fails to compile on Fedora 32.