### PR TITLE
Compatibility with OpenCV 4

### DIFF
--- a/src/goesproc/config.cc
+++ b/src/goesproc/config.cc
@@ -5,6 +5,12 @@
 
 #include <util/string.h>
 
+#ifndef CV_VERSION_EPOCH
+#if CV_VERSION_MAJOR >= 4
+#include <opencv2/imgcodecs/legacy/constants_c.h>
+#endif
+#endif
+
 using namespace nlohmann;
 using namespace util;
 


### PR DESCRIPTION
The definition for `CV_LOAD_IMAGE_UNCHANGED` was moved to a separate legacy header in OpenCV 4.

See opencv/opencv#13195

Thanks!