### PR TITLE
Make doc build compatible with older sphinx versions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,6 +6,8 @@
 # full list see the documentation:
 # http://www.sphinx-doc.org/en/stable/config
 
+import sphinx_rtd_theme
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -77,6 +79,7 @@ pygments_style = 'sphinx'
 # a list of builtin themes.
 #
 html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
This was necessary to build the docs on CentOS 7, which has sphinx 1.2.3 and sphinx_rtd_theme 0.2.4.