### PR TITLE
Update README.txt for mapping

### DIFF
--- a/share/ne/README.txt
+++ b/share/ne/README.txt
@@ -10,3 +10,12 @@ To generate these files, install Node.js, and subsequently the
 `shapefile` package (https://www.npmjs.com/package/shapefile). This
 package ships with the `shp2json` tool that converts a Shapefile (SHP)
 to the GeoJSON format.
+
+Using `ogr2ogr` instead of `shp2json' will allow conversion of 
+a Shapefile (SHP) from a points based geometry like most GIS
+systems, to a polygon based geometry shape that is processed
+by goestools with this command:
+
+ogr2ogr -f "GeoJSON" -dialect SQLite -sql "select ST_Buffer(geometry,
+0.01) from inputfile" output.json inputfile.shp
+

--- a/share/ne/README.txt
+++ b/share/ne/README.txt
@@ -16,6 +16,8 @@ a Shapefile (SHP) from a points based geometry like most GIS
 systems, to a polygon based geometry shape that is processed
 by goestools with this command:
 
-ogr2ogr -f "GeoJSON" -dialect SQLite -sql "select ST_Buffer(geometry,
-0.01) from inputfile" output.json inputfile.shp
+```
+ogr2ogr -f "GeoJSON" -dialect SQLite -sql "select ST_Buffer(geometry, 0.01) from inputfile" output.json inputfile.shp
+```
 
+See https://gdal.org/ for installation instructions for `ogr2ogr`.


### PR DESCRIPTION
Using `ogr2ogr` instead of `shp2json' will allow conversion of 
a Shapefile (SHP) from a points based geometry like most GIS
systems, to a polygon based geometry shape that is processed
by goestools with this command:

ogr2ogr -f "GeoJSON" -dialect SQLite -sql "select ST_Buffer(geometry,
0.01) from inputfile" output.json inputfile.shp