### PR TITLE
Add `libproj-dev` as a required dependency

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -47,7 +47,8 @@ Install system dependencies:
     git-core \
     libopencv-dev \
     libproj-dev \
-    zlib1g-dev
+    zlib1g-dev \
+    libproj-dev
 
 If you want to run goesrecv on this machine, you also have to install
 the development packages of the drivers the SDRs you want to use;


### PR DESCRIPTION
Goesproc requires libproj-dev to run, let's add this to this list of depends.

Without it, if and you run Goesproc you will get the following error.

> Invalid configuration: The configuration file includes directives to add a map overlay, but goesproc was compiled without the proj library. Make sure to install the proj library before compiling goesproc, and look for a message saying 'Found proj' when running cmake. Install proj on Debian/Ubuntu/Raspbian by running: 'sudo apt-get install -y libproj-dev'.