### PR TITLE
Replace deprecated use of std::unary_function

### DIFF
--- a/src/goesproc/types.h
+++ b/src/goesproc/types.h
@@ -41,7 +41,7 @@ struct Channel {
 using SegmentKey = std::tuple<std::string, std::string, std::string>;
 
 // Corresponding hash function
-struct SegmentKeyHash : public std::unary_function<SegmentKey, std::size_t> {
+struct SegmentKeyHash : public std::function<std::size_t(SegmentKey)> {
   std::size_t operator()(const SegmentKey& k) const {
     return
       std::hash<std::string>()(std::get<0>(k)) ^


### PR DESCRIPTION
Fix the following build warning:
```
In file included from /home/src/goestools/src/goesproc/handler_goesn.h:10,
                 from /home/src/goestools/src/goesproc/goesproc.cc:16:
/home/src/goestools/src/goesproc/types.h:44:37: warning: 'template<class _Arg, class _Result> struct std::unary_function' is deprecated [-Wdeprecated-declarations]
   44 | struct SegmentKeyHash : public std::unary_function<SegmentKey, std::size_t> {
      |                                     ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12/string:48,
                 from /usr/include/c++/12/bits/locale_classes.h:40,
                 from /usr/include/c++/12/bits/ios_base.h:41,
                 from /usr/include/c++/12/ios:42,
                 from /usr/include/c++/12/istream:38,
                 from /usr/include/c++/12/fstream:38,
                 from /home/src/goestools/src/goesproc/goesproc.cc:2:
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
```
