### PR TITLE
Differentiate between DSI-CAPE and DSI-LI

### DIFF
--- a/src/goesproc/handler_goesr.cc
+++ b/src/goesproc/handler_goesr.cc
@@ -180,7 +180,7 @@ GOESRProduct::GOESRProduct(const std::shared_ptr<const lrit::File>& f)
       if (k == "_NAME") {
         if(v == "atmosphere_convective_available_potential_energy_wrt_surface") product_.nameShort += "-CAPE";
         if(v == "temperature_difference_between_ambient_air_and_air_lifted_adiabatically_from_the_surface") product_.nameShort += "-LI";
-	    break;
+        break;
       }
     }
   }


### PR DESCRIPTION
**Starting on June 30, 2023, NOAA started downlinking two DSI files on the HRIT downlink:** DSI CAPE, and DSI Lifted Index. Before, only DSI CAPE was downlinked. You can read about DSI types at http://cimss.ssec.wisc.edu/goes/OCLOFactSheetPDFs/ABIQuickGuide_BaselineDerivedStabilityIndices.pdf?fbclid=IwAR1T5jTfYOtjZ3S8LWRbK8aDdZH2TGW_-UdK0ePc30LJSbq4tqKLQFAzCfQ.

**Unlike other GOES-R products, this product is not differentiated in the file name**. Both DSI files have the same name, and even the same timestamp. The only differentiating factor is _NAME in the ImageDataFunctionHeader. As such, the current version of goestools cannot differentiate and save both images.

**This PR fixes the problem by parsing the ImageDataFunctionHeader if the product is DSI**. It then updates the product name to DSI-CAPE or DSI-LI, depending on the _NAME value. If a DSI image is downlinked without the header, or if it has a different _NAME, the product will stay as DSI.

Users' goesproc.conf files will need to be updated to handle the distinction. Here are some LRIT files for testing: [zip](https://github.com/pietern/goestools/files/11938936/DSI.CAPE.and.LI.-.HRIT.zip)